### PR TITLE
Implemented multi-init guard

### DIFF
--- a/android/src/main/java/com/deepwall/RNDeepWallModule.kt
+++ b/android/src/main/java/com/deepwall/RNDeepWallModule.kt
@@ -21,8 +21,23 @@ open class RNDeepWallModule(private val reactContext: ReactApplicationContext) :
 
   var deepWallEmitter = RNDeepWallEmitter(reactContext)
 
+  /*
+   * Whether DeepWall has initialized before or not. This flag will
+   * be used to prevent multiple initializations.
+   */
+  private var isDeepWallInitialized = false
+
   @ReactMethod
   fun initialize(apiKey: String?, environment: Int) {
+
+    // If the library has initialized before, do not do anything.
+    if (isDeepWallInitialized) {
+      return
+    }
+
+    // Set the flag as true here to prevent double calls getting through.
+    isDeepWallInitialized = true
+
     observeDeepWallEvents()
     val deepWallEnvironment = if (environment == 1) DeepWallEnvironment.SANDBOX else DeepWallEnvironment.PRODUCTION
     initDeepWallWith(currentActivity!!.application, this.currentActivity!!, apiKey!!, deepWallEnvironment)


### PR DESCRIPTION
There is an issue when developing React Native apps that have `deepwall-react-native-sdk` package installed.

Imagine a RN app that has Deepwall properly set up, and has a listener for a Deepwall event as such:

```js
DeepWallEventBus.getInstance().addListener(DeepWallEvents.PAYWALL_OPENED, this.paywallOpenedListener = data => {
    console.log('paywall opened');
});
```

What a developer would see in their terminal when the app is starting is a string saying `paywall opened`. When the developer makes a change on the app's Javascript codes and saves the file, the app reloads to reflect the changes. What that developer now sees in their terminal when the app is reloading is **two new strings** saying `paywall opened`.

The reason the event listeners getting called twice is because on the reload action, the underlying native app does not actually restart. Only the Javascript part restarts. Every time JS part restarts, it calls the initDeepwall() function to start Deepwall's functionalities, but on recurring reloads of the JS part the Deepwall is already initiated. See the simple scenario below for alternative explanation.

> - **Developer builds and starts the app on a simulator or a device.**
> - **Phone starts the underlying native app.**
> - **Native app starts JS app.**
> - **JS app calls initDeepwall().**
> - **Native app initializes Deepwall.**
> - At this point app is fully loaded and ready to use.
> - **Developer makes a change on some part of the code.**
> - **Native app reloads JS app.**
> - At this point Deepwall is still intact and already initialized, because the native app did not restart.
> - **JS app calls initDeepwall().**
> - **Native app initializes Deepwall AGAIN.**
> - At this point any event listeners will be triggered twice for each occurrence.

This PR introduces a simple boolean flag and a guard check to fix that problem.